### PR TITLE
feat: 냉장고 화면 수정

### DIFF
--- a/frontend/.idea/inspectionProfiles/Project_Default.xml
+++ b/frontend/.idea/inspectionProfiles/Project_Default.xml
@@ -1,0 +1,57 @@
+<component name="InspectionProjectProfileManager">
+  <profile version="1.0">
+    <option name="myName" value="Project Default" />
+    <inspection_tool class="ComposePreviewDimensionRespectsLimit" enabled="true" level="WARNING" enabled_by_default="true">
+      <option name="composableFile" value="true" />
+      <option name="previewFile" value="true" />
+    </inspection_tool>
+    <inspection_tool class="ComposePreviewMustBeTopLevelFunction" enabled="true" level="ERROR" enabled_by_default="true">
+      <option name="composableFile" value="true" />
+      <option name="previewFile" value="true" />
+    </inspection_tool>
+    <inspection_tool class="ComposePreviewNeedsComposableAnnotation" enabled="true" level="ERROR" enabled_by_default="true">
+      <option name="composableFile" value="true" />
+      <option name="previewFile" value="true" />
+    </inspection_tool>
+    <inspection_tool class="ComposePreviewNotSupportedInUnitTestFiles" enabled="true" level="ERROR" enabled_by_default="true">
+      <option name="composableFile" value="true" />
+      <option name="previewFile" value="true" />
+    </inspection_tool>
+    <inspection_tool class="GlancePreviewDimensionRespectsLimit" enabled="true" level="WARNING" enabled_by_default="true">
+      <option name="composableFile" value="true" />
+    </inspection_tool>
+    <inspection_tool class="GlancePreviewMustBeTopLevelFunction" enabled="true" level="ERROR" enabled_by_default="true">
+      <option name="composableFile" value="true" />
+    </inspection_tool>
+    <inspection_tool class="GlancePreviewNeedsComposableAnnotation" enabled="true" level="ERROR" enabled_by_default="true">
+      <option name="composableFile" value="true" />
+    </inspection_tool>
+    <inspection_tool class="GlancePreviewNotSupportedInUnitTestFiles" enabled="true" level="ERROR" enabled_by_default="true">
+      <option name="composableFile" value="true" />
+    </inspection_tool>
+    <inspection_tool class="PreviewAnnotationInFunctionWithParameters" enabled="true" level="ERROR" enabled_by_default="true">
+      <option name="composableFile" value="true" />
+      <option name="previewFile" value="true" />
+    </inspection_tool>
+    <inspection_tool class="PreviewApiLevelMustBeValid" enabled="true" level="ERROR" enabled_by_default="true">
+      <option name="composableFile" value="true" />
+      <option name="previewFile" value="true" />
+    </inspection_tool>
+    <inspection_tool class="PreviewDeviceShouldUseNewSpec" enabled="true" level="WEAK WARNING" enabled_by_default="true">
+      <option name="composableFile" value="true" />
+      <option name="previewFile" value="true" />
+    </inspection_tool>
+    <inspection_tool class="PreviewFontScaleMustBeGreaterThanZero" enabled="true" level="ERROR" enabled_by_default="true">
+      <option name="composableFile" value="true" />
+      <option name="previewFile" value="true" />
+    </inspection_tool>
+    <inspection_tool class="PreviewMultipleParameterProviders" enabled="true" level="ERROR" enabled_by_default="true">
+      <option name="composableFile" value="true" />
+      <option name="previewFile" value="true" />
+    </inspection_tool>
+    <inspection_tool class="PreviewPickerAnnotation" enabled="true" level="ERROR" enabled_by_default="true">
+      <option name="composableFile" value="true" />
+      <option name="previewFile" value="true" />
+    </inspection_tool>
+  </profile>
+</component>

--- a/frontend/app/src/main/java/com/example/frontend/FridgeSceen.kt
+++ b/frontend/app/src/main/java/com/example/frontend/FridgeSceen.kt
@@ -1,13 +1,11 @@
 package com.example.frontend
 
 import androidx.compose.foundation.Image
-import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.grid.GridCells
 import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
 import androidx.compose.foundation.lazy.grid.items
 import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
@@ -20,25 +18,38 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import androidx.navigation.NavController
 import androidx.navigation.compose.rememberNavController
+import androidx.navigation.NavController
 import com.example.frontend.extrafunc.BottomNavigationBar
-import com.example.frontend.extrafunc.getImageForCategory
 import com.example.frontend.extrafunc.navigateSafely
-import java.time.LocalDate
-import java.time.temporal.ChronoUnit
+import androidx.lifecycle.viewmodel.compose.viewModel
 
-
-@Preview(showBackground = true)
-@Composable
-fun PreviewFridgeScreen() {
-    FridgeScreen(navController = rememberNavController())
-}
+val historyListState = mutableStateListOf<Ingredient>()  // 소비,낭비된 재료 리스트 추가
 
 @Composable
-fun FridgeScreen(navController: NavController) {
-    val groupedIngredients by remember { mutableStateOf(fridgeList.groupBy { it.category }) }
-    val expandedState = remember { mutableStateMapOf<String, Boolean>() }
+fun FridgeScreen(
+    navController: NavController
+) {
+    // 상태를 SnapshotStateList로 관리
+    val fridgeListState = remember { mutableStateListOf<Ingredient>().apply { addAll(fridgeList) } }
+
+    val groupedIngredients = fridgeListState
+        .filter { it.state == IngredientState.FRESH } // 신선 상태만 필터링
+        .groupBy { it.category }
+
+
+    // 유통기한이 지난 재료 자동 낭비 처리 (중복 방지 적용)
+    LaunchedEffect(fridgeListState) {
+        fridgeListState.forEach { ingredient ->
+            if (ingredient.getDday() < 0 && ingredient.state != IngredientState.WASTED) {
+                ingredient.waste()
+
+                // 기존 ID가 존재하는 경우 제거 후 추가
+                historyListState.removeIf { it.id == ingredient.id }
+                historyListState.add(ingredient)
+            }
+        }
+    }
 
     Box(
         modifier = Modifier.fillMaxSize()
@@ -46,7 +57,9 @@ fun FridgeScreen(navController: NavController) {
         Image(
             modifier = Modifier
                 .fillMaxSize()
-                .padding(bottom = WindowInsets.navigationBars.asPaddingValues().calculateBottomPadding()),
+                .padding(
+                    bottom = WindowInsets.navigationBars.asPaddingValues().calculateBottomPadding()
+                ),
             painter = painterResource(R.drawable.main_screen),
             contentDescription = null,
             contentScale = ContentScale.Crop
@@ -57,11 +70,9 @@ fun FridgeScreen(navController: NavController) {
                 .fillMaxSize()
                 .padding(16.dp)
         ) {
-            //냉장고 재료 관리 텍스트 항상 표시
             Text(
                 text = "냉장고 재료 관리",
                 fontSize = 25.sp,
-                fontFamily = pretendard,
                 fontWeight = FontWeight(600),
                 color = Color(0xFF1A72D3),
                 modifier = Modifier
@@ -70,13 +81,25 @@ fun FridgeScreen(navController: NavController) {
                 textAlign = TextAlign.Center
             )
 
+            Button(
+                onClick = {
+                    // 소비/낭비 내역 보기 화면으로 이동
+                    //navController.navigate(Routes.HistoryListScreen)
+                          },
+                modifier = Modifier
+                    .wrapContentWidth()
+                    .padding(bottom = 16.dp),
+                colors = ButtonDefaults.buttonColors(containerColor = Color(0xFF1A72D3))
+            ) {
+                Text(text = "소비/낭비 내역 보기", color = Color.White, fontSize = 18.sp)
+            }
+
             Box(
                 modifier = Modifier
                     .weight(1f)
                     .padding(bottom = 70.dp)
             ) {
                 if (groupedIngredients.isEmpty()) {
-                    //냉장고가 비었을 때 메시지 표시
                     Box(
                         modifier = Modifier.fillMaxSize(),
                         contentAlignment = Alignment.Center
@@ -84,7 +107,6 @@ fun FridgeScreen(navController: NavController) {
                         Text(
                             text = "냉장고가 비어 있습니다.",
                             fontSize = 18.sp,
-                            fontFamily = pretendard,
                             fontWeight = FontWeight(500),
                             color = Color.Gray,
                             textAlign = TextAlign.Center
@@ -96,143 +118,69 @@ fun FridgeScreen(navController: NavController) {
                     ) {
                         groupedIngredients.forEach { (category, items) ->
                             item {
-                                Box(
-                                    modifier = Modifier
-                                        .fillMaxWidth()
-                                        .background(Color.Transparent, RoundedCornerShape(10.dp))
-                                        .padding(12.dp)
-                                ) {
-                                    Column {
-                                        Row(
-                                            modifier = Modifier.fillMaxWidth(),
-                                            verticalAlignment = Alignment.CenterVertically
-                                        ) {
-                                            Text(
-                                                text = "$category (${items.size})",
-                                                fontSize = 20.sp,
-                                                fontFamily = pretendard,
-                                                fontWeight = FontWeight(500),
-                                                color = Color(0xFF1A72D3),
-                                                modifier = Modifier.weight(1f)
-                                            )
-                                            Button(
-                                                onClick = {
-                                                    expandedState[category] =
-                                                        !(expandedState[category] ?: false)
-                                                },
-                                                colors = ButtonDefaults.buttonColors(
-                                                    containerColor = Color(0xFF90CAF8)
-                                                )
-                                            ) {
-                                                Text(
-                                                    text = if (expandedState[category] == true) "접기" else "자세히",
-                                                    color = Color.White
-                                                )
+                                Column {
+
+                                    Text(
+                                        text = "$category (${items.size})",
+                                        fontSize = 20.sp,
+                                        fontWeight = FontWeight(500),
+                                        color = Color(0xFF1A72D3),
+                                        modifier = Modifier.padding(8.dp)
+                                    )
+
+                                    LazyVerticalGrid(
+                                        columns = GridCells.Fixed(3),
+                                        modifier = Modifier
+                                            .fillMaxWidth()
+                                            .padding(top = 8.dp)
+                                            .heightIn(max = 350.dp)
+                                    ) {
+                                        items(items.sortedBy { it.expiryDate }) { ingredient ->
+                                            FridgeItem(ingredient) {
+                                                // UI 업데이트를 위해 상태 변경 후 리스트 갱신
+                                                ingredient.consume()
+                                                fridgeListState.remove(ingredient)
+                                                fridgeListState.add(ingredient) // 변경된 상태 반영
+                                                if (ingredient.state == IngredientState.CONSUMED || ingredient.state == IngredientState.WASTED) {
+                                                    historyListState.removeIf { it.id == ingredient.id }
+                                                    historyListState.add(ingredient)
+                                                }
+
                                             }
                                         }
 
-                                        //유통기한이 짧은 순으로 정렬 후 표시
-                                        if (expandedState[category] == true) {
-                                            LazyVerticalGrid(
-                                                columns = GridCells.Fixed(3),
-                                                modifier = Modifier
-                                                    .fillMaxWidth()
-                                                    .padding(top = 8.dp)
-                                                    .heightIn(max = 350.dp)
-                                            ) {
-                                                items(items.sortedBy { it.expiryDate }) { ingredient ->
-                                                    FridgeItem(ingredient)
-                                                }
-                                            }
-                                        }
                                     }
                                 }
-                                Spacer(modifier = Modifier.height(8.dp))
                             }
                         }
                     }
                 }
             }
         }
-    }
 
-    Column(
-        modifier = Modifier
-            .fillMaxSize()
-            .padding(bottom = 0.dp),
-        verticalArrangement = Arrangement.Bottom
-    ) {
-        BottomNavigationBar(
-            selectedTab = "Ingredient",
-            onTabSelected = {
-                if (it != "Profile") {
-                    navigateSafely(navController, it)
-                }
-            },
-            navController = navController
-        )
+
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(bottom = 0.dp),
+            verticalArrangement = Arrangement.Bottom
+        ) {
+            BottomNavigationBar(
+                selectedTab = "Main",
+                onTabSelected = {
+                    if (it != "Profile") {
+                        navigateSafely(navController, it)
+                    }
+                },
+                navController = navController
+            )
+        }
+
     }
 }
 
+@Preview(showBackground = true)
 @Composable
-fun FridgeItem(ingredient: Ingredient) {
-    val dDay = ChronoUnit.DAYS.between(LocalDate.now(), ingredient.expiryDate).toInt()
-
-    //D-Day에 따른 색상 설정
-    val dDayColor = when {
-        dDay == 0 -> Color(0xFFD32F2F) // 당일 (빨강)
-        dDay in 1..3 -> Color(0xFFFFA000) // 1~3일 (주황)
-        else -> Color(0xFF388E3C) // 4일 이상 (초록)
-    }
-
-
-    Card(
-        modifier = Modifier
-            .size(100.dp)
-            .padding(8.dp),
-        shape = RoundedCornerShape(10.dp),
-        colors = CardDefaults.cardColors(containerColor = Color.White),
-        elevation = CardDefaults.cardElevation(defaultElevation = 4.dp)
-    ) {
-        Box(
-            modifier = Modifier.fillMaxSize()
-        ) {
-            Box(
-                modifier = Modifier
-                    .align(Alignment.TopStart)
-                    .padding(4.dp)
-                    .background(dDayColor, RoundedCornerShape(4.dp))
-                    .padding(horizontal = 6.dp, vertical = 2.dp)
-            ) {
-                Text(
-                    text = "D-$dDay",
-                    fontSize = 10.sp,
-                    color = Color.White
-                )
-            }
-
-            Column(
-                modifier = Modifier
-                    .fillMaxSize()
-                    .padding(top = 12.dp),
-                horizontalAlignment = Alignment.CenterHorizontally,
-                verticalArrangement = Arrangement.Center
-            ) {
-                Image(
-                    painter = painterResource(id = getImageForCategory(ingredient.category)),
-                    contentDescription = ingredient.name,
-                    modifier = Modifier
-                        .size(50.dp)
-                        .padding(bottom = 4.dp),
-                    contentScale = ContentScale.Fit
-                )
-                Text(
-                    text = ingredient.name,
-                    fontSize = 12.sp,
-                    color = Color(0xFF1045A1),
-                    textAlign = TextAlign.Center
-                )
-            }
-        }
-    }
+fun PreviewFridgeScreen() {
+    FridgeScreen(navController = rememberNavController())
 }

--- a/frontend/app/src/main/java/com/example/frontend/FridgeSceen.kt
+++ b/frontend/app/src/main/java/com/example/frontend/FridgeSceen.kt
@@ -84,7 +84,7 @@ fun FridgeScreen(
             Button(
                 onClick = {
                     // 소비/낭비 내역 보기 화면으로 이동
-                    //navController.navigate(Routes.HistoryListScreen)
+                    navController.navigate(Routes.HistoryListScreen)
                           },
                 modifier = Modifier
                     .wrapContentWidth()

--- a/frontend/app/src/main/java/com/example/frontend/HistoryListScreen.kt
+++ b/frontend/app/src/main/java/com/example/frontend/HistoryListScreen.kt
@@ -1,0 +1,137 @@
+package com.example.frontend
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.grid.GridCells
+import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
+import androidx.compose.foundation.lazy.grid.items
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.mutableStateListOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.snapshots.SnapshotStateList
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.navigation.NavController
+import androidx.navigation.compose.rememberNavController
+import java.time.LocalDate
+
+@Preview(showBackground = true)
+@Composable
+fun PreviewConsumedListScreen() {
+    val sampleConsumedList = remember {
+        mutableStateListOf(
+            Ingredient(
+                name = "재료1",
+                addedDate = LocalDate.now().minusDays(5), // 5일 전에 추가
+                expiryDate = LocalDate.now().minusDays(1), // 1일 전에 유통기한 만료
+                category = "카테고리1",
+                state = IngredientState.CONSUMED
+            ),
+            Ingredient(
+                name = "재료1",
+                addedDate = LocalDate.now().minusDays(7), // 7일 전에 추가
+                expiryDate = LocalDate.now().minusDays(2),
+                category = "카테고리1",
+                state = IngredientState.WASTED
+            ),
+            Ingredient(
+                name = "재료3",
+                addedDate = LocalDate.now().minusDays(10), // 10일 전에 추가
+                expiryDate = LocalDate.now().minusDays(3),
+                category = "카테고리3",
+                state = IngredientState.WASTED
+            ),
+            Ingredient(
+                name = "재료4",
+                addedDate = LocalDate.now().minusDays(10), // 10일 전에 추가
+                expiryDate = LocalDate.now().minusDays(3),
+                category = "카테고리3",
+                state = IngredientState.WASTED
+            )
+        )
+    }
+    HistoryListScreen(navController = rememberNavController(), historyList = sampleConsumedList)
+}
+
+@Composable
+fun HistoryListScreen(navController: NavController, historyList: SnapshotStateList<Ingredient>) {
+
+    // 소비/낭비 상태인 재료만 필터링
+    val groupedHistory = historyList
+        .filter { it.state == IngredientState.CONSUMED || it.state == IngredientState.WASTED }
+        .groupBy { it.category }
+
+
+    Column(modifier = Modifier.fillMaxSize().padding(16.dp)) {
+        Text(
+            text = "소비/낭비 내역",
+            fontSize = 25.sp,
+            fontWeight = FontWeight.Bold,
+            color = Color(0xFF1A72D3),
+            modifier = Modifier.fillMaxWidth().padding(bottom = 16.dp),
+            textAlign = TextAlign.Center
+        )
+
+        // 뒤로 가기 버튼 추가
+        Button(
+            onClick = { navController.popBackStack() },
+            modifier = Modifier.fillMaxWidth().padding(bottom = 16.dp),
+            colors = ButtonDefaults.buttonColors(containerColor = Color(0xFF90CAF8))
+        ) {
+            Text(text = "뒤로 가기", color = Color.White, fontSize = 18.sp)
+        }
+
+        if (groupedHistory.isEmpty()) {
+            Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+                Text("소비/낭비된 재료가 없습니다.", fontSize = 18.sp, fontWeight = FontWeight(500), color = Color.Gray)
+            }
+        } else {
+            LazyColumn(modifier = Modifier.fillMaxSize()) {
+                groupedHistory.forEach { (category, items) ->
+                    item {
+                        Column {
+                            Text(
+                                text = "$category (${items.size})",
+                                fontSize = 20.sp,
+                                fontWeight = FontWeight(500),
+                                color = Color(0xFF1A72D3),
+                                modifier = Modifier.padding(8.dp)
+                            )
+
+                            // LazyVerticalGrid를 사용하여 카드 형식으로 표시
+                            Column(modifier = Modifier.fillMaxWidth().padding(top = 8.dp)) {
+                                LazyVerticalGrid(
+                                    columns = GridCells.Fixed(3),
+                                    modifier = Modifier
+                                        .fillMaxWidth()
+                                        .heightIn(max = 350.dp) // 스크롤 가능
+                                ) {
+                                    // 고유 ID를 key 값으로 사용하여 중복 방지
+                                    items(historyList.sortedBy { it.expiryDate }, key = { it.id }) { ingredient ->
+                                        HistoryItem(ingredient) // 개별 재료 표시
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+
+            }
+
+        }
+    }
+}

--- a/frontend/app/src/main/java/com/example/frontend/Ingredient.kt
+++ b/frontend/app/src/main/java/com/example/frontend/Ingredient.kt
@@ -2,29 +2,31 @@ package com.example.frontend
 
 import java.time.LocalDate
 import java.time.temporal.ChronoUnit
+import java.util.UUID
+
+enum class IngredientState {
+    FRESH, CONSUMED, WASTED
+}
 
 data class Ingredient(
-    val name: String,         // 제품명
-    val category: String,     // 식품군
-    val addedDate: LocalDate, // 제품 추가 날짜
-    val expiryDate: LocalDate // 유통기한
+    val id: String = UUID.randomUUID().toString(),  // 고유 ID 자동 생성
+    val name: String,
+    val category: String,
+    val addedDate: LocalDate,
+    val expiryDate: LocalDate,
+    var state: IngredientState = IngredientState.FRESH
 ) {
-    // D-day 계산 (유통기한 - 추가한 날짜)
+
     fun getDday(): Long {
         return ChronoUnit.DAYS.between(addedDate, expiryDate)
     }
-}
 
-//enum class IngredientStatus {
-//    FRESH, CONSUMED, DISCARDED
-//}
-//
-//data class Ingredient(
-//    val name: String,
-//    val addedDate: LocalDate,
-//    val expiryDate: LocalDate,
-//    val category: String,
-//    var status: IngredientStatus = IngredientStatus.FRESH
-//) {
-//    fun getDday(): Int = ChronoUnit.DAYS.between(LocalDate.now(), expiryDate).toInt()
-//}
+    fun waste() {
+        state = IngredientState.WASTED // 낭비 상태로 변경
+    }
+
+    fun consume() {
+        state = IngredientState.CONSUMED // 소비 상태로 변경
+
+    }
+}

--- a/frontend/app/src/main/java/com/example/frontend/MainScreen.kt
+++ b/frontend/app/src/main/java/com/example/frontend/MainScreen.kt
@@ -42,7 +42,6 @@ import androidx.compose.runtime.remember
 import androidx.navigation.NavController
 import androidx.navigation.compose.rememberNavController
 import com.example.frontend.extrafunc.BottomNavigationBar
-import com.example.frontend.extrafunc.DDayBar
 
 @Preview(showBackground = true)
 @Composable

--- a/frontend/app/src/main/java/com/example/frontend/Routes.kt
+++ b/frontend/app/src/main/java/com/example/frontend/Routes.kt
@@ -9,4 +9,5 @@ object Routes {
     var ReciptScreen = "ReciptScreen"
     var CameraScreen = "Camerascreen"
     var FridgeScreen = "FridgeScreen"
+    var HistoryListScreen = "HistoryListScreen"
 }

--- a/frontend/app/src/main/java/com/example/frontend/extrafunc/DDayBar.kt
+++ b/frontend/app/src/main/java/com/example/frontend/extrafunc/DDayBar.kt
@@ -1,4 +1,4 @@
-package com.example.frontend.extrafunc
+package com.example.frontend
 import android.util.Log
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
@@ -6,6 +6,7 @@ import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.snapshots.SnapshotStateList
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -13,14 +14,18 @@ import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import com.example.frontend.Ingredient
-import com.example.frontend.R
+import java.time.LocalDate
+import java.time.temporal.ChronoUnit
 
 @Composable
-fun DDayBar(fridgeList: List<Ingredient>) {
-    val sortedIngredients = fridgeList.sortedBy { it.getDday() }.take(3)
+fun DDayBar(
+    //fridgeList: List<Ingredient>
+    historyList: SnapshotStateList<Ingredient>
+) {
 
-    Log.d("FridgeListLog", "DDayBar에 전달된 fridgeList: $fridgeList")
+    val sortedIngredients = historyList
+        .filter { it.state == IngredientState.FRESH } // 신선 상태만 필터링
+    Log.d("FridgeListLog", "DDayBar에 전달된 fridgeList: $historyList")
 
     Row(
         modifier = Modifier
@@ -37,7 +42,7 @@ fun DDayBar(fridgeList: List<Ingredient>) {
         )
 
         sortedIngredients.forEach { ingredient ->
-            val dDay = ingredient.getDday().toInt() // ✅ Long → Int 변환
+            val dDay = ChronoUnit.DAYS.between(LocalDate.now(), ingredient.expiryDate).toInt()
 
             //D-Day에 따른 색상 설정
             val dDayColor = when {
@@ -46,9 +51,11 @@ fun DDayBar(fridgeList: List<Ingredient>) {
                 else -> Color(0xFF388E3C) // 4일 이상 (초록)
             }
 
+
             Column(
                 horizontalAlignment = Alignment.CenterHorizontally
             ) {
+
                 Image(
                     painter = painterResource(id = getImageForCategory(ingredient.category)),
                     contentDescription = ingredient.name,
@@ -69,21 +76,7 @@ fun DDayBar(fridgeList: List<Ingredient>) {
                     color = Color(0xFF1A72D3)
                 )
             }
-        }
-    }
-}
 
-@Composable
-fun getImageForCategory(category: String): Int {
-    return when (category) {
-        "즉석식품" -> R.drawable.alarm_icon
-        "음료" -> R.drawable.back_arrow
-        "가공식품" -> R.drawable.email_icon
-        "조미식품" -> R.drawable.password_icon
-        "유제품" -> R.drawable.analysis_icon
-        "신선식품" -> R.drawable.calendar_icon
-        "어패류" -> R.drawable.camera_icon
-        "육류" -> R.drawable.search_icon
-        else -> R.drawable.name_icon // 기본 아이콘
+        }
     }
 }

--- a/frontend/app/src/main/java/com/example/frontend/extrafunc/DatePickers.kt
+++ b/frontend/app/src/main/java/com/example/frontend/extrafunc/DatePickers.kt
@@ -7,6 +7,9 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.material3.rememberDatePickerState
 import androidx.compose.runtime.Composable
+import java.time.Instant
+import java.time.LocalDate
+import java.time.ZoneId
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -14,14 +17,24 @@ fun DatePickerModal(
     onDateSelected: (Long?) -> Unit,
     onDismiss: () -> Unit
 ) {
-    val datePickerState = rememberDatePickerState()
+    // 오늘 날짜를 밀리초로 변환
+    val todayMillis = LocalDate.now().atStartOfDay(ZoneId.systemDefault()).toInstant().toEpochMilli()
+
+    // 날짜 선택기의 최소 날짜를 오늘 날짜로 설정
+    val datePickerState = rememberDatePickerState(
+        initialSelectedDateMillis = todayMillis,
+        initialDisplayedMonthMillis = todayMillis
+    )
 
     DatePickerDialog(
         onDismissRequest = onDismiss,
         confirmButton = {
             TextButton(onClick = {
-                onDateSelected(datePickerState.selectedDateMillis)
-                onDismiss()
+                val selectedDateMillis = datePickerState.selectedDateMillis
+                if (selectedDateMillis != null && selectedDateMillis >= todayMillis) {
+                    onDateSelected(selectedDateMillis)
+                    onDismiss()
+                }
             }) {
                 Text("OK")
             }
@@ -32,6 +45,36 @@ fun DatePickerModal(
             }
         }
     ) {
-        DatePicker(state = datePickerState)
+        DatePicker(
+            state = datePickerState
+        )
     }
 }
+
+//@OptIn(ExperimentalMaterial3Api::class)
+//@Composable
+//fun DatePickerModal(
+//    onDateSelected: (Long?) -> Unit,
+//    onDismiss: () -> Unit
+//) {
+//    val datePickerState = rememberDatePickerState()
+//
+//    DatePickerDialog(
+//        onDismissRequest = onDismiss,
+//        confirmButton = {
+//            TextButton(onClick = {
+//                onDateSelected(datePickerState.selectedDateMillis)
+//                onDismiss()
+//            }) {
+//                Text("OK")
+//            }
+//        },
+//        dismissButton = {
+//            TextButton(onClick = onDismiss) {
+//                Text("Cancel")
+//            }
+//        }
+//    ) {
+//        DatePicker(state = datePickerState)
+//    }
+//}

--- a/frontend/app/src/main/java/com/example/frontend/extrafunc/FreshCheckApp.kt
+++ b/frontend/app/src/main/java/com/example/frontend/extrafunc/FreshCheckApp.kt
@@ -8,12 +8,14 @@ import androidx.navigation.compose.rememberNavController
 import com.example.frontend.CalendarScreen
 import com.example.frontend.CameraScreen
 import com.example.frontend.FridgeScreen
+import com.example.frontend.HistoryListScreen
 import com.example.frontend.IngredientScreen
 import com.example.frontend.LoginScreen
 import com.example.frontend.MainScreen
 import com.example.frontend.ReciptScreen
 import com.example.frontend.RegisterScreen
 import com.example.frontend.Routes
+import com.example.frontend.historyListState
 
 
 @Composable
@@ -60,6 +62,11 @@ fun FreshCheckApp() {
             //냉장고 화면
             composable(Routes.FridgeScreen) {
                 FridgeScreen(navController)
+            }
+
+            //소비/낭비 내역 추가
+            composable(Routes.HistoryListScreen) {
+                HistoryListScreen(navController, historyListState)
             }
 
         })

--- a/frontend/app/src/main/java/com/example/frontend/extrafunc/FridgeItem.kt
+++ b/frontend/app/src/main/java/com/example/frontend/extrafunc/FridgeItem.kt
@@ -1,0 +1,122 @@
+package com.example.frontend
+
+import android.util.Log
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import java.time.LocalDate
+import java.time.temporal.ChronoUnit
+
+@Composable
+fun FridgeItem(ingredient: Ingredient, onStateChange: () -> Unit) {
+    val dDay = ChronoUnit.DAYS.between(LocalDate.now(), ingredient.expiryDate).toInt()
+
+    // 유통기한이 지나면 자동으로 WASTED 상태로 변경
+    LaunchedEffect(dDay) {
+        if (dDay < 0 && ingredient.state != IngredientState.WASTED) {
+            ingredient.waste()
+            onStateChange() // 상태 변경 후 UI 업데이트
+        }
+    }
+
+    val dDayColor = when {
+        dDay == 0 -> Color(0xFFD32F2F) // 당일 (빨강)
+        dDay in 1..3 -> Color(0xFFFFA000) // 1~3일 (주황)
+        else -> Color(0xFF388E3C) // 4일 이상 (초록)
+    }
+
+    Card(
+        modifier = Modifier
+            .size(100.dp)
+            .padding(8.dp),
+        shape = RoundedCornerShape(10.dp),
+        colors = CardDefaults.cardColors(containerColor = Color.White),
+        elevation = CardDefaults.cardElevation(defaultElevation = 4.dp)
+    ) {
+        Box(
+            modifier = Modifier.fillMaxSize()
+        ) {
+            Column(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(top = 12.dp),
+                horizontalAlignment = Alignment.CenterHorizontally,
+                verticalArrangement = Arrangement.Center
+            ) {
+                Image(
+                    painter = painterResource(id = getImageForCategory(ingredient.category)),
+                    contentDescription = ingredient.name,
+                    modifier = Modifier
+                        .size(50.dp)
+                        .padding(bottom = 4.dp),
+                    contentScale = ContentScale.Fit
+                )
+                Text(
+                    text = ingredient.name,
+                    fontSize = 12.sp,
+                    fontWeight = FontWeight.Bold,
+                    color = Color(0xFF1045A1),
+                    textAlign = TextAlign.Center
+                )
+            }
+
+            // D-Day 표시
+            Box(
+                modifier = Modifier
+                    .align(Alignment.TopStart)
+                    .padding(4.dp)
+                    .background(dDayColor, RoundedCornerShape(4.dp))
+                    .padding(horizontal = 6.dp, vertical = 2.dp)
+            ) {
+                Text(
+                    text = "D-$dDay",
+                    fontSize = 10.sp,
+                    color = Color.White
+                )
+            }
+
+            // 소비 버튼 추가
+            Box(
+                modifier = Modifier
+                    .align(Alignment.TopEnd)
+                    .padding(4.dp)
+                    .background(Color(0xFF1976D2), RoundedCornerShape(4.dp))
+                    .clickable {
+                        ingredient.consume() // 상태를 소비로 변경
+                        onStateChange() // UI 업데이트
+                        Log.d("FridgeDebugItem", "소비됨: ${ingredient.name}")
+                    }
+                    .padding(horizontal = 6.dp, vertical = 2.dp)
+            ) {
+                Text(
+                    text = "소비",
+                    fontSize = 10.sp,
+                    color = Color.White
+                )
+            }
+
+
+        }
+    }
+}

--- a/frontend/app/src/main/java/com/example/frontend/extrafunc/HistoryItem.kt
+++ b/frontend/app/src/main/java/com/example/frontend/extrafunc/HistoryItem.kt
@@ -1,0 +1,85 @@
+package com.example.frontend
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+
+@Composable
+fun HistoryItem(ingredient: Ingredient) {
+    val backgroundColor = when (ingredient.state) {
+        IngredientState.CONSUMED -> Color(0xFF90CAF8) // 소비된 재료: 블루
+        IngredientState.WASTED -> Color(0xFFD32F2F) // 낭비된 재료: 레드
+        else -> Color.White
+    }
+
+    Card(
+        modifier = Modifier
+            .size(100.dp)
+            .padding(8.dp),
+        shape = RoundedCornerShape(10.dp),
+        colors = CardDefaults.cardColors(containerColor = backgroundColor),
+        elevation = CardDefaults.cardElevation(defaultElevation = 4.dp)
+    ) {
+        Box(
+            modifier = Modifier.fillMaxSize()
+        ) {
+            Column(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(top = 12.dp),
+                horizontalAlignment = Alignment.CenterHorizontally,
+                verticalArrangement = Arrangement.Center
+            ) {
+                Image(
+                    painter = painterResource(id = getImageForCategory(ingredient.category)),
+                    contentDescription = ingredient.name,
+                    modifier = Modifier
+                        .size(50.dp)
+                        .padding(bottom = 4.dp),
+                    contentScale = ContentScale.Fit
+                )
+                Text(
+                    text = ingredient.name,
+                    fontSize = 12.sp,
+                    fontWeight = FontWeight.Bold,
+                    color = Color.White,
+                    textAlign = TextAlign.Center
+                )
+            }
+
+            // 소비된 날짜 또는 낭비된 날짜 표시
+            Box(
+                modifier = Modifier
+                    .align(Alignment.TopStart)
+                    .padding(4.dp)
+                    .background(Color.Black.copy(alpha = 0.7f), RoundedCornerShape(4.dp))
+                    .padding(horizontal = 6.dp, vertical = 2.dp)
+            ) {
+                Text(
+                    text = if (ingredient.state == IngredientState.CONSUMED) "소비됨" else "낭비됨",
+                    fontSize = 10.sp,
+                    color = Color.White
+                )
+            }
+        }
+    }
+}

--- a/frontend/app/src/main/java/com/example/frontend/extrafunc/getImageForCategory.kt
+++ b/frontend/app/src/main/java/com/example/frontend/extrafunc/getImageForCategory.kt
@@ -1,0 +1,18 @@
+package com.example.frontend
+
+import androidx.compose.runtime.Composable
+
+@Composable
+fun getImageForCategory(category: String): Int {
+    return when (category) {
+        "즉석식품" -> R.drawable.alarm_icon
+        "음료" -> R.drawable.back_arrow
+        "가공식품" -> R.drawable.email_icon
+        "조미식품" -> R.drawable.password_icon
+        "유제품" -> R.drawable.analysis_icon
+        "신선식품" -> R.drawable.calendar_icon
+        "어패류" -> R.drawable.camera_icon
+        "육류" -> R.drawable.search_icon
+        else -> R.drawable.name_icon // 기본 아이콘
+    }
+}


### PR DESCRIPTION
1. 냉장고 물품 보여주는 방식 변경 1-1. 개별 파일로 분리
1-2. 소비 버튼 추가
1-3. 접기, 자세히 삭제
2. Ingredient에 상태 및 고유아이디 추가