### PR TITLE
feat: 분석페이지 추가 및 수정

### DIFF
--- a/frontend/app/src/main/java/com/example/frontend/AnalysisSceen.kt
+++ b/frontend/app/src/main/java/com/example/frontend/AnalysisSceen.kt
@@ -1,0 +1,148 @@
+package com.example.frontend
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.asPaddingValues
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.navigationBars
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.navigation.NavController
+import androidx.navigation.compose.rememberNavController
+import com.example.frontend.extrafunc.BottomNavigationBar
+import com.example.frontend.extrafunc.navigateSafely
+
+@Composable
+fun AnalysisScreen(navController: NavController) {
+    val categoryScores = remember { calculateCategoryScores(fridgeList) }
+    var selectedCategory by remember { mutableStateOf<String?>(null) }
+
+    Box(
+        modifier = Modifier.fillMaxSize()
+    ) {
+        //배경 이미지
+        Image(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(
+                    bottom = WindowInsets.navigationBars.asPaddingValues().calculateBottomPadding()
+                ),
+            painter = painterResource(R.drawable.main_screen), // 배경 설정
+            contentDescription = null,
+            contentScale = ContentScale.Crop
+        )
+
+
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(16.dp)
+        ) {
+            Spacer(modifier = Modifier.height(60.dp))
+            Text(
+                text = "카테고리 별 소비 점수",
+                fontSize = 25.sp,
+                fontFamily = pretendard,
+                fontWeight = FontWeight(600),
+                color = Color(0xFF1A72D3),
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(bottom = 16.dp),
+                textAlign = TextAlign.Center
+            )
+            Box(
+                modifier = Modifier
+                    .weight(1f)
+                    .padding(bottom = 100.dp)
+            ) {
+                LazyColumn {
+                    items(categoryScores) { categoryScore ->
+                        Card(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .padding(vertical = 8.dp)
+                                .clickable {
+                                    selectedCategory = categoryScore.category // 다이얼로그 열기
+                                },
+                            colors = CardDefaults.cardColors(containerColor = Color(0xFFE3F2FD))
+                        ) {
+                            Column(
+                                modifier = Modifier.padding(16.dp)
+                            ) {
+                                Text(
+                                    text = categoryScore.category,
+                                    fontSize = 20.sp,
+                                    fontFamily = pretendard,
+                                    fontWeight = FontWeight.Bold
+                                )
+                                Spacer(modifier = Modifier.height(4.dp))
+                                Text(text = "총 재료 수: ${categoryScore.totalItems}",fontFamily = pretendard)
+                                Text(text = "소비: ${categoryScore.consumedItems}, 낭비: ${categoryScore.wastedItems}, 신선: ${categoryScore.freshItems}",fontFamily = pretendard)
+                                Text(
+                                    text = "점수: ${categoryScore.score}점",
+                                    fontSize = 18.sp,
+                                    fontWeight = FontWeight.Bold,
+                                    fontFamily = pretendard,
+                                    color = Color(0xFF1E88E5)
+                                )
+                            }
+                        }
+                    }
+                }
+            }
+
+        }
+
+        //카테고리 다이얼로그 표시
+        selectedCategory?.let { category ->
+            AnalysisDetailDialog(category = category, ingredientList = fridgeList, onDismiss = { selectedCategory = null })
+        }
+
+        //하단 네비게이션 바 추가
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(bottom = 0.dp),
+            verticalArrangement = Arrangement.Bottom
+        ) {
+            BottomNavigationBar(
+                selectedTab = "Main",
+                onTabSelected = {
+                },
+                navController = navController
+            )
+        }
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+fun PreviewAnalysisScreen() {
+    AnalysisScreen(navController = rememberNavController())
+}
+

--- a/frontend/app/src/main/java/com/example/frontend/CalendarScreen.kt
+++ b/frontend/app/src/main/java/com/example/frontend/CalendarScreen.kt
@@ -1,6 +1,7 @@
 package com.example.frontend
 
 import androidx.activity.compose.BackHandler
+import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
@@ -9,10 +10,13 @@ import androidx.compose.foundation.lazy.grid.GridCells
 import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
 import androidx.compose.foundation.lazy.grid.items
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.res.painterResource
@@ -26,12 +30,22 @@ import com.example.frontend.extrafunc.BottomNavigationBar
 import com.example.frontend.extrafunc.navigateSafely
 import java.time.LocalDate
 import java.time.YearMonth
+import java.time.format.DateTimeFormatter
+
 
 @Composable
 fun CalendarScreen(navController: NavController) {
-    var selectedMonth by remember { mutableStateOf(LocalDate.now().monthValue) }
     val today = LocalDate.now()
+    var selectedMonth by remember { mutableStateOf(today.monthValue) }
     val currentYear = today.year
+    var selectedDate by remember { mutableStateOf<LocalDate?>(null) }
+    var showPopup by remember { mutableStateOf(false) }
+
+    val ingredientsByDate = remember { mutableStateMapOf<LocalDate, List<Ingredient>>() }
+    ingredientsByDate.clear()
+    fridgeList.groupBy { it.expiryDate }.forEach { (date, ingredients) ->
+        ingredientsByDate[date] = ingredients
+    }
 
     BackHandler {
         // 뒤로 가기 방지
@@ -91,16 +105,21 @@ fun CalendarScreen(navController: NavController) {
                 modifier = Modifier.fillMaxWidth(),
                 horizontalAlignment = Alignment.CenterHorizontally
             ) {
-                // 상단 바 (월 선택)
-                CalendarHeader(selectedMonth) { newMonth ->
-                    selectedMonth = newMonth
-                }
-
-                // 요일 표시
+                CalendarHeader(selectedMonth) { newMonth -> selectedMonth = newMonth }
                 DaysOfWeekHeader()
 
-                // 캘린더 날짜 표시
-                CalendarGrid(selectedMonth, currentYear, today)
+                CalendarGrid(
+                    selectedMonth = selectedMonth,
+                    currentYear = currentYear,
+                    today = today,
+                    onDateSelected = { date ->
+                        if (ingredientsByDate[date]?.isNotEmpty() == true) {
+                            selectedDate = date
+                            showPopup = true
+                        }
+                    },
+                    ingredientsByDate = ingredientsByDate
+                )
             }
 
         }
@@ -108,14 +127,31 @@ fun CalendarScreen(navController: NavController) {
 
         BottomNavigationBar(
             selectedTab = "Main", onTabSelected = {
-                if (it != "Profile") { // 오른쪽 버튼은 비활성화
-                    navigateSafely(navController, it)
-                }
             }, navController = navController
         )
     }
 
+    // 재료 목록 팝업
+    if (showPopup && selectedDate != null) {
+        AlertDialog(
+            onDismissRequest = { showPopup = false },
+            title = { Text(text = "${selectedDate?.format(DateTimeFormatter.ofPattern("yyyy-MM-dd"))} 재료 목록") },
+            text = {
+                Column {
+                    ingredientsByDate[selectedDate]?.forEach { ingredient ->
+                        Text(text = "• ${ingredient.name} (${ingredient.state})", fontSize = 16.sp)
+                    }
+                }
+            },
+            confirmButton = {
+                TextButton(onClick = { showPopup = false }) {
+                    Text("닫기")
+                }
+            }
+        )
+    }
 }
+
 
 /** 캘린더 상단 (월 선택 + 오늘 날짜로 이동 버튼) */
 @Composable
@@ -239,9 +275,15 @@ fun DaysOfWeekHeader() {
 
 /** 캘린더 날짜 그리드 */
 @Composable
-fun CalendarGrid(selectedMonth: Int, currentYear: Int, today: LocalDate) {
+fun CalendarGrid(
+    selectedMonth: Int,
+    currentYear: Int,
+    today: LocalDate,
+    onDateSelected: (LocalDate) -> Unit,
+    ingredientsByDate: Map<LocalDate, List<Ingredient>>
+) {
     val yearMonth = YearMonth.of(currentYear, selectedMonth)
-    val daysInMonth = yearMonth.lengthOfMonth() // 월의 일 수 자동 계산
+    val daysInMonth = yearMonth.lengthOfMonth()
     val firstDayOfMonth = yearMonth.atDay(1).dayOfWeek.value % 7 // 0 = 일요일
     val totalDays = (1..daysInMonth).map { it.toString() }.toMutableList()
 
@@ -254,32 +296,40 @@ fun CalendarGrid(selectedMonth: Int, currentYear: Int, today: LocalDate) {
         items(totalDays) { day ->
             Box(
                 modifier = Modifier
+                    .fillMaxWidth()
                     .wrapContentHeight()
-                    .padding(4.dp),
-                contentAlignment = Alignment.Center
+                    .padding(4.dp)
+                    .clickable {
+                        if (day.isNotEmpty()) {
+                            val selectedDate = LocalDate.of(currentYear, selectedMonth, day.toInt())
+                            onDateSelected(selectedDate)
+                        }
+                    },
+                contentAlignment = Alignment.TopCenter // 모든 요소를 상단 정렬
             ) {
                 if (day.isNotEmpty()) {
-                    val isToday =
-                        today.dayOfMonth.toString() == day && today.monthValue == selectedMonth
+                    val date = LocalDate.of(currentYear, selectedMonth, day.toInt())
+                    val isToday = date == today
+                    val ingredients = ingredientsByDate[date] ?: emptyList()
 
                     Column(
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .padding(vertical = 8.dp),
+                        modifier = Modifier.wrapContentHeight(), // 최소 높이 유지
+                        verticalArrangement = Arrangement.Top, // 모든 요소를 상단에 정렬
                         horizontalAlignment = Alignment.CenterHorizontally
                     ) {
-
-                        // Today 라벨
+                        // "Today" 텍스트를 맨 위에 정렬
                         if (isToday) {
                             Text(
                                 text = "Today",
                                 fontSize = 10.sp,
+                                fontFamily = pretendard,
                                 fontWeight = FontWeight(500),
-                                color = Color(0xFF1A72D3)
+                                color = Color(0xFF1A72D3),
+                                modifier = Modifier.padding(bottom = 0.dp) // 날짜와 간격 조정
                             )
                         }
 
-                        // 날짜 텍스트
+                        // 날짜 표시
                         Text(
                             text = day,
                             fontSize = 16.sp,
@@ -288,7 +338,31 @@ fun CalendarGrid(selectedMonth: Int, currentYear: Int, today: LocalDate) {
                             color = if (isToday) Color(0xFF1A72D3) else Color.Black
                         )
 
+                        Spacer(modifier = Modifier.height(2.dp)) // 날짜와 줄 사이 여백 추가
 
+                        // **재료 상태 밑줄 (최대 3개까지 표시)**
+                        if (ingredients.isNotEmpty()) {
+                            val displayedIngredients = ingredients.take(3) // 최대 3개까지만 표시
+
+                            Canvas(
+                                modifier = Modifier
+                                    .fillMaxWidth(0.8f) // 줄 길이 조정
+                                    .height(10.dp) // 줄 높이 유지
+                            ) {
+                                val lineHeight = 10f // 선 굵기 조정
+                                val lineSpacing = lineHeight + 3f // 줄 간격 조정
+
+                                displayedIngredients.forEachIndexed { index, ingredient ->
+                                    val lineY = index * lineSpacing // 간격 조절
+                                    drawLine(
+                                        color = categoryColorMap[ingredient.category] ?: Color.Gray,
+                                        start = Offset(0f, lineY),
+                                        end = Offset(size.width, lineY),
+                                        strokeWidth = lineHeight
+                                    )
+                                }
+                            }
+                        }
                     }
                 }
             }
@@ -296,8 +370,72 @@ fun CalendarGrid(selectedMonth: Int, currentYear: Int, today: LocalDate) {
     }
 }
 
+// **카테고리별 색상 지정**
+val categoryColorMap = mapOf(
+    "가공식품" to Color(0xFFFF5733),  // 오렌지
+    "간식" to Color(0xFFFFD700),  // 노랑
+    "신선식품" to Color(0xFF4CAF50),  // 초록
+    "어패류" to Color(0xFF1E90FF),  // 파랑
+    "유제품" to Color(0xFF8A2BE2),  // 보라
+    "육류" to Color(0xFFA52A2A),  // 갈색
+    "음료" to Color(0xFF00CED1),  // 청록
+    "조미식품" to Color(0xFFFF69B4),  // 핑크
+    "즉석식품" to Color(0xFF808080)   // 회색
+)
 @Preview(showBackground = true)
 @Composable
-fun PreviewCalendar() {
+fun PreviewCalendarScreen() {
+    // 테스트용 재료 데이터
+    fridgeList.clear()
+    fridgeList.addAll(
+        listOf(
+            Ingredient(
+                name = "재료1",
+                addedDate = LocalDate.now().minusDays(5), // 5일 전에 추가
+                expiryDate = LocalDate.now().minusDays(1), // 1일 전에 유통기한 만료
+                category = "가공식품",
+                state = IngredientState.CONSUMED
+            ),
+            Ingredient(
+                name = "재료1",
+                addedDate = LocalDate.now().minusDays(7), // 7일 전에 추가
+                expiryDate = LocalDate.now().minusDays(2),
+                category = "간식",
+                state = IngredientState.WASTED
+            ),
+            Ingredient(
+                name = "재료3",
+                addedDate = LocalDate.now().minusDays(10), // 10일 전에 추가
+                expiryDate = LocalDate.now().minusDays(3),
+                category = "신선식품",
+                state = IngredientState.WASTED
+            ),
+            Ingredient(
+                name = "재료4",
+                addedDate = LocalDate.now().minusDays(0), // 10일 전에 추가
+                expiryDate = LocalDate.now().minusDays(0),
+                category = "신선식품",
+                state = IngredientState.WASTED
+            ),
+            Ingredient(
+                name = "재료4",
+                addedDate = LocalDate.now().minusDays(0), // 10일 전에 추가
+                expiryDate = LocalDate.now().minusDays(0),
+                category = "유제품",
+                state = IngredientState.WASTED
+            ),
+            Ingredient(
+                name = "재료4",
+                addedDate = LocalDate.now().minusDays(0), // 10일 전에 추가
+                expiryDate = LocalDate.now().minusDays(0),
+                category = "육류",
+                state = IngredientState.WASTED
+            ),
+
+
+
+            )
+    )
+
     CalendarScreen(navController = rememberNavController())
 }

--- a/frontend/app/src/main/java/com/example/frontend/FridgeSceen.kt
+++ b/frontend/app/src/main/java/com/example/frontend/FridgeSceen.kt
@@ -30,23 +30,42 @@ val historyListState = mutableStateListOf<Ingredient>()  // 소비,낭비된 재
 fun FridgeScreen(
     navController: NavController
 ) {
-    // 상태를 SnapshotStateList로 관리
-    val fridgeListState = remember { mutableStateListOf<Ingredient>().apply { addAll(fridgeList) } }
+//    // 상태를 SnapshotStateList로 관리
+//    val fridgeListState = remember { mutableStateListOf<Ingredient>().apply { addAll(fridgeList) } }
+//
+//    val groupedIngredients = fridgeListState
+//        .filter { it.state == IngredientState.FRESH } // 신선 상태만 필터링
+//        .groupBy { it.category }
+//
+//
+//    // 유통기한이 지난 재료 자동 낭비 처리 (중복 방지 적용)
+//    LaunchedEffect(fridgeListState) {
+//        fridgeListState.forEach { ingredient ->
+//            if (ingredient.getDday() < 0 && ingredient.state != IngredientState.WASTED) {
+//                ingredient.waste()
+//
+//                // 기존 ID가 존재하는 경우 제거 후 추가
+//                historyListState.removeIf { it.id == ingredient.id }
+//                historyListState.add(ingredient)
+//            }
+//        }
+//    }
 
-    val groupedIngredients = fridgeListState
+    val groupedIngredients = fridgeList
         .filter { it.state == IngredientState.FRESH } // 신선 상태만 필터링
         .groupBy { it.category }
 
 
     // 유통기한이 지난 재료 자동 낭비 처리 (중복 방지 적용)
-    LaunchedEffect(fridgeListState) {
-        fridgeListState.forEach { ingredient ->
+    LaunchedEffect(fridgeList) {
+        fridgeList.forEach { ingredient ->
             if (ingredient.getDday() < 0 && ingredient.state != IngredientState.WASTED) {
                 ingredient.waste()
 
                 // 기존 ID가 존재하는 경우 제거 후 추가
                 historyListState.removeIf { it.id == ingredient.id }
                 historyListState.add(ingredient)
+
             }
         }
     }
@@ -70,9 +89,11 @@ fun FridgeScreen(
                 .fillMaxSize()
                 .padding(16.dp)
         ) {
+            Spacer(modifier = Modifier.height(60.dp))
             Text(
                 text = "냉장고 재료 관리",
                 fontSize = 25.sp,
+                fontFamily = pretendard,
                 fontWeight = FontWeight(600),
                 color = Color(0xFF1A72D3),
                 modifier = Modifier
@@ -82,22 +103,19 @@ fun FridgeScreen(
             )
 
             Button(
-                onClick = {
-                    // 소비/낭비 내역 보기 화면으로 이동
-                    navController.navigate(Routes.HistoryListScreen)
-                          },
+                onClick = { navController.navigate(Routes.HistoryListScreen) }, // 소비/낭비 내역 보기 화면으로 이동
                 modifier = Modifier
                     .wrapContentWidth()
                     .padding(bottom = 16.dp),
                 colors = ButtonDefaults.buttonColors(containerColor = Color(0xFF1A72D3))
             ) {
-                Text(text = "소비/낭비 내역 보기", color = Color.White, fontSize = 18.sp)
+                Text(text = "소비/낭비 내역 보기", color = Color.White, fontSize = 18.sp,fontFamily = pretendard)
             }
 
             Box(
                 modifier = Modifier
                     .weight(1f)
-                    .padding(bottom = 70.dp)
+                    .padding(bottom = 100.dp)
             ) {
                 if (groupedIngredients.isEmpty()) {
                     Box(
@@ -107,6 +125,7 @@ fun FridgeScreen(
                         Text(
                             text = "냉장고가 비어 있습니다.",
                             fontSize = 18.sp,
+                            fontFamily = pretendard,
                             fontWeight = FontWeight(500),
                             color = Color.Gray,
                             textAlign = TextAlign.Center
@@ -123,6 +142,7 @@ fun FridgeScreen(
                                     Text(
                                         text = "$category (${items.size})",
                                         fontSize = 20.sp,
+                                        fontFamily = pretendard,
                                         fontWeight = FontWeight(500),
                                         color = Color(0xFF1A72D3),
                                         modifier = Modifier.padding(8.dp)
@@ -139,8 +159,10 @@ fun FridgeScreen(
                                             FridgeItem(ingredient) {
                                                 // UI 업데이트를 위해 상태 변경 후 리스트 갱신
                                                 ingredient.consume()
-                                                fridgeListState.remove(ingredient)
-                                                fridgeListState.add(ingredient) // 변경된 상태 반영
+                                                //fridgeListState.remove(ingredient)
+                                                //fridgeListState.add(ingredient) // 변경된 상태 반영
+                                                fridgeList.remove(ingredient)
+                                                fridgeList.add(ingredient) // 변경된 상태 반영
                                                 if (ingredient.state == IngredientState.CONSUMED || ingredient.state == IngredientState.WASTED) {
                                                     historyListState.removeIf { it.id == ingredient.id }
                                                     historyListState.add(ingredient)
@@ -168,9 +190,7 @@ fun FridgeScreen(
             BottomNavigationBar(
                 selectedTab = "Main",
                 onTabSelected = {
-                    if (it != "Profile") {
-                        navigateSafely(navController, it)
-                    }
+
                 },
                 navController = navController
             )

--- a/frontend/app/src/main/java/com/example/frontend/HistoryListScreen.kt
+++ b/frontend/app/src/main/java/com/example/frontend/HistoryListScreen.kt
@@ -64,13 +64,14 @@ fun PreviewConsumedListScreen() {
             )
         )
     }
-    HistoryListScreen(navController = rememberNavController(), historyList = sampleConsumedList)
+    HistoryListScreen(navController = rememberNavController()
+        , historyList = sampleConsumedList)
 }
 
 @Composable
 fun HistoryListScreen(navController: NavController, historyList: SnapshotStateList<Ingredient>) {
 
-    // 소비/낭비 상태인 재료만 필터링
+    // 소비/낭비 상태인 재료만 필터링하여 카테고리별 그룹화
     val groupedHistory = historyList
         .filter { it.state == IngredientState.CONSUMED || it.state == IngredientState.WASTED }
         .groupBy { it.category }
@@ -120,9 +121,9 @@ fun HistoryListScreen(navController: NavController, historyList: SnapshotStateLi
                                         .fillMaxWidth()
                                         .heightIn(max = 350.dp) // 스크롤 가능
                                 ) {
-                                    // 고유 ID를 key 값으로 사용하여 중복 방지
-                                    items(historyList.sortedBy { it.expiryDate }, key = { it.id }) { ingredient ->
-                                        HistoryItem(ingredient) // 개별 재료 표시
+                                    // **카테고리별 아이템만 전달하여 중복 방지**
+                                    items(items.sortedBy { it.expiryDate }, key = { it.id }) { ingredient ->
+                                        HistoryItem(ingredient)
                                     }
                                 }
                             }

--- a/frontend/app/src/main/java/com/example/frontend/Ingredient.kt
+++ b/frontend/app/src/main/java/com/example/frontend/Ingredient.kt
@@ -14,7 +14,8 @@ data class Ingredient(
     val category: String,
     val addedDate: LocalDate,
     val expiryDate: LocalDate,
-    var state: IngredientState = IngredientState.FRESH
+    var state: IngredientState = IngredientState.FRESH,
+    var stateChangeDate: LocalDate? = null // 상태 변경 날짜 추가
 ) {
 
     fun getDday(): Long {
@@ -23,10 +24,11 @@ data class Ingredient(
 
     fun waste() {
         state = IngredientState.WASTED // 낭비 상태로 변경
+        stateChangeDate = LocalDate.now() // 낭비 상태 변경 날짜 기록
     }
 
     fun consume() {
         state = IngredientState.CONSUMED // 소비 상태로 변경
-
+        stateChangeDate = LocalDate.now() // 낭비 상태 변경 날짜 기록
     }
 }

--- a/frontend/app/src/main/java/com/example/frontend/IngredientScreen.kt
+++ b/frontend/app/src/main/java/com/example/frontend/IngredientScreen.kt
@@ -33,6 +33,7 @@ import java.time.format.DateTimeFormatter
 
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
+import androidx.lifecycle.viewmodel.compose.viewModel
 import com.example.frontend.extrafunc.BottomNavigationBar
 import com.example.frontend.extrafunc.CartIngredientRow
 import com.example.frontend.extrafunc.DatePickerModal
@@ -43,7 +44,7 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 
 // 냉장고 재료 리스트 (전역 변수)
-val fridgeList = mutableStateListOf<Ingredient>()
+var fridgeList = mutableStateListOf<Ingredient>()
 
 // 장바구니 리스트 (전역 변수로 변경하여 상태 유지)
 val cartList = mutableStateListOf<String>()
@@ -51,7 +52,8 @@ val cartList = mutableStateListOf<String>()
 val ingredientList = mutableStateListOf<Ingredient>()
 
 @Composable
-fun IngredientScreen(navController: NavController) {
+fun IngredientScreen(navController: NavController
+) {
     var selectedTabIndex by remember { mutableStateOf(-1) }
     var selfIngredient by remember { mutableStateOf(TextFieldValue("")) }
     var isTextFieldFocused by remember { mutableStateOf(false) }
@@ -59,7 +61,7 @@ fun IngredientScreen(navController: NavController) {
     // 유통기한 및 식품군 관련 상태
     var selectedDate by remember { mutableStateOf(LocalDate.now()) }
     var showDatePicker by remember { mutableStateOf(false) }
-    val foodCategories = listOf("즉석식품", "음료", "가공식품", "조미식품", "유제품", "신선식품", "어패류", "육류")
+    val foodCategories = listOf("가공식품", "간식", "신선식품", "어패류", "유제품", "육류", "음료", "조미식품","즉석식품")
     var expanded by remember { mutableStateOf(false) }
     var selectedCategory by remember { mutableStateOf(foodCategories.first()) }
 
@@ -89,7 +91,7 @@ fun IngredientScreen(navController: NavController) {
         contentScale = ContentScale.Crop
     )
 
-// 팝업 메시지
+    // 팝업 메시지
     if (showPopup) {
         TopPopupMessage(message = "새로운 재료(${ingredientList.size})가 추가되었습니다") {
             showPopup = false
@@ -780,9 +782,7 @@ fun IngredientScreen(navController: NavController) {
         Spacer(modifier = Modifier.weight(1f))
         BottomNavigationBar(
             selectedTab = "Ingredient", onTabSelected = {
-                if (it != "Profile") { // 오른쪽 버튼은 비활성화
-                    navigateSafely(navController, it)
-                }
+
             }, navController = navController
         )
     }

--- a/frontend/app/src/main/java/com/example/frontend/MainScreen.kt
+++ b/frontend/app/src/main/java/com/example/frontend/MainScreen.kt
@@ -55,11 +55,9 @@ fun PreviewMainScreen() {
 fun MainScreen(
     navController: NavController
 ) {
-
-
     var selectedTab by remember { mutableStateOf("Main") }
 
-    var fridgeList by remember { mutableStateOf(fridgeList) }
+    //var fridgeList by remember { mutableStateOf(fridgeList) }
 
     BackHandler {
         // 뒤로 가기 버튼을 눌렀을 때 아무 동작도 하지 않도록 설정
@@ -115,7 +113,7 @@ fun MainScreen(
                 .wrapContentHeight()
                 .background(color = Color(0xFFEAF6FF))
         ) {
-            DDayBar(fridgeList) // 냉장고 리스트에서 유통기한 가까운 3개 표시
+            DDayBar() // 냉장고 리스트에서 유통기한 가까운 3개 표시
         }
 
     }
@@ -134,7 +132,7 @@ fun MainScreen(
                     color = Color(0xFFEAF6FF), shape = RoundedCornerShape(size = 20.dp)
                 )
                 .clickable {
-
+                    navController.navigate(Routes.AnalysisScreen)
                 }) {
                 Icon(
                     modifier = Modifier
@@ -166,7 +164,6 @@ fun MainScreen(
                     color = Color(0xFFEAF6FF), shape = RoundedCornerShape(size = 20.dp)
                 )
                 .clickable {
-                    //navController.navigate(Routes.CalendarScreen)
                     navController.navigate(Routes.CalendarScreen)
                 }) {
                 Icon(

--- a/frontend/app/src/main/java/com/example/frontend/Routes.kt
+++ b/frontend/app/src/main/java/com/example/frontend/Routes.kt
@@ -10,4 +10,6 @@ object Routes {
     var CameraScreen = "Camerascreen"
     var FridgeScreen = "FridgeScreen"
     var HistoryListScreen = "HistoryListScreen"
+    var AnalysisScreen = "AnalysisScreen"
+    var SettingScreen = "SettingScreen"
 }

--- a/frontend/app/src/main/java/com/example/frontend/SettingScreen.kt
+++ b/frontend/app/src/main/java/com/example/frontend/SettingScreen.kt
@@ -1,0 +1,103 @@
+package com.example.frontend
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.asPaddingValues
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.navigationBars
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.navigation.NavController
+import androidx.navigation.compose.rememberNavController
+import com.example.frontend.extrafunc.BottomNavigationBar
+import com.example.frontend.extrafunc.navigateSafely
+
+@Composable
+fun SettingScreen(navController: NavController){
+    Box(
+        modifier = Modifier.fillMaxSize()
+    ) {
+        //배경 이미지
+        Image(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(
+                    bottom = WindowInsets.navigationBars.asPaddingValues().calculateBottomPadding()
+                ),
+            painter = painterResource(R.drawable.main_screen), // 배경 설정
+            contentDescription = null,
+            contentScale = ContentScale.Crop
+        )
+
+
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(16.dp)
+        ) {
+            Spacer(modifier = Modifier.height(60.dp))
+            Text(
+                text = "원하는 알림 방식을 선택해주세요",
+                fontSize = 25.sp,
+                fontFamily = pretendard,
+                fontWeight = FontWeight(600),
+                color = Color(0xFF1A72D3),
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(bottom = 16.dp),
+                textAlign = TextAlign.Center
+            )
+            Box(
+                modifier = Modifier
+                    .weight(1f)
+                    .padding(bottom = 100.dp)
+            ) {
+
+            }
+
+        }
+
+        //하단 네비게이션 바 추가
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(bottom = 0.dp),
+            verticalArrangement = Arrangement.Bottom
+        ) {
+            BottomNavigationBar(
+                selectedTab = "Profile",
+                onTabSelected = {
+
+                },
+                navController = navController
+            )
+        }
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+fun PreviewSettingScreen() {
+    SettingScreen(navController = rememberNavController())
+}

--- a/frontend/app/src/main/java/com/example/frontend/extrafunc/AnalysisDetailDialog.kt
+++ b/frontend/app/src/main/java/com/example/frontend/extrafunc/AnalysisDetailDialog.kt
@@ -1,0 +1,151 @@
+package com.example.frontend
+
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.compose.ui.window.Dialog
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import java.time.LocalDate
+import java.time.format.DateTimeFormatter
+
+@Composable
+fun AnalysisDetailDialog(
+    category: String,
+    ingredientList: List<Ingredient>,
+    onDismiss: () -> Unit
+) {
+    val dateFormatter = DateTimeFormatter.ofPattern("yyyy.MM.dd")
+
+    // **정렬 로직**
+    val categoryItems = ingredientList.filter { it.category == category }
+        .sortedWith(
+            compareBy<Ingredient> { it.state.ordinal } // 1️⃣ 상태 기준 (FRESH → CONSUMED → WASTED)
+                .thenBy { it.stateChangeDate ?: LocalDate.MAX } // 2️⃣ 같은 상태일 때 날짜가 빠른 순 정렬
+        )
+
+    Dialog(onDismissRequest = { onDismiss() }) {
+        Card(
+            shape = RoundedCornerShape(12.dp),
+            colors = CardDefaults.cardColors(containerColor = Color.White),
+            modifier = Modifier
+                .fillMaxWidth(0.9f)
+                .wrapContentHeight()
+        ) {
+            Column(
+                modifier = Modifier.padding(16.dp),
+                verticalArrangement = Arrangement.Center,
+                horizontalAlignment = Alignment.CenterHorizontally
+            ) {
+                Text(
+                    text = "$category 상세 분석",
+                    fontSize = 22.sp,
+                    fontFamily = pretendard,
+                    fontWeight = FontWeight.Bold,
+                    modifier = Modifier.padding(bottom = 16.dp)
+                )
+
+                LazyColumn(
+                    modifier = Modifier.heightIn(max = 300.dp)
+                ) {
+                    items(categoryItems) { ingredient ->
+                        val statusText = when (ingredient.state) {
+                            IngredientState.CONSUMED -> "소비됨"
+                            IngredientState.WASTED -> "낭비됨"
+                            else -> "신선함"
+                        }
+                        val changeDateText = ingredient.stateChangeDate?.format(dateFormatter) ?: "변경 없음"
+
+                        Card(
+                            modifier = Modifier.fillMaxWidth().padding(vertical = 4.dp),
+                            colors = CardDefaults.cardColors(
+                                containerColor = when (ingredient.state) {
+                                    IngredientState.CONSUMED -> Color(0xFFC8E6C9) // 초록 (소비)
+                                    IngredientState.WASTED -> Color(0xFFFFCDD2) // 빨강 (낭비)
+                                    else -> Color(0xFFFFF9C4) // 노랑 (신선)
+                                }
+                            )
+                        ) {
+                            Row(
+                                modifier = Modifier.padding(16.dp),
+                                horizontalArrangement = Arrangement.SpaceBetween
+                            ) {
+                                Text(
+                                    text = "${ingredient.name} - $statusText ($changeDateText)",
+                                    fontSize = 16.sp,
+                                    fontFamily = pretendard,
+                                    fontWeight = FontWeight.Medium
+                                )
+                            }
+                        }
+                    }
+                }
+
+                Spacer(modifier = Modifier.height(16.dp))
+
+                // 닫기 버튼
+                Button(
+                    onClick = { onDismiss() },
+                    colors = ButtonDefaults.buttonColors(containerColor = Color(0xFF90CAF8))
+                ) {
+                    Text(text = "닫기", color = Color.White, fontSize = 18.sp)
+                }
+            }
+        }
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+fun PreviewCategoryDetailDialog() {
+    val sampleIngredients = listOf(
+        Ingredient(
+            name = "소고기",
+            category = "육류",
+            addedDate = LocalDate.now().minusDays(5),
+            expiryDate = LocalDate.now().plusDays(5),
+            state = IngredientState.FRESH
+        ),
+        Ingredient(
+            name = "돼지고기",
+            category = "육류",
+            addedDate = LocalDate.now().minusDays(10),
+            expiryDate = LocalDate.now().minusDays(2),
+            state = IngredientState.CONSUMED,
+            stateChangeDate = LocalDate.of(2024, 2, 12) // 소비 날짜
+        ),
+        Ingredient(
+            name = "닭고기",
+            category = "육류",
+            addedDate = LocalDate.now().minusDays(20),
+            expiryDate = LocalDate.now().minusDays(5),
+            state = IngredientState.WASTED,
+            stateChangeDate = LocalDate.of(2023, 9, 23) // 낭비 날짜
+        ),
+        Ingredient(
+            name = "양고기",
+            category = "육류",
+            addedDate = LocalDate.now().minusDays(15),
+            expiryDate = LocalDate.now().minusDays(5),
+            state = IngredientState.FRESH
+        ),
+        Ingredient(
+            name = "오리고기",
+            category = "육류",
+            addedDate = LocalDate.now().minusDays(12),
+            expiryDate = LocalDate.now().minusDays(6),
+            state = IngredientState.CONSUMED,
+            stateChangeDate = LocalDate.of(2024, 1, 20) // 소비 날짜
+        )
+    )
+
+    AnalysisDetailDialog(category = "육류", ingredientList = sampleIngredients, onDismiss = {})
+}

--- a/frontend/app/src/main/java/com/example/frontend/extrafunc/BottomNavigationBar.kt
+++ b/frontend/app/src/main/java/com/example/frontend/extrafunc/BottomNavigationBar.kt
@@ -64,12 +64,12 @@ fun BottomNavigationBar(
 
         Spacer(modifier = Modifier.width(15.dp))
 
-        // 우측 버튼: 클릭 불가능 (비활성화)
+        // 우측 버튼: 세팅 화면 이동
         NavigationButton(
             iconRes = R.drawable.profile_bottom_icon,
             isSelected = selectedTab == "Profile",
             onClick = {
-                //
+                navigateSafely(navController, Routes.SettingScreen)
             }
         )
     }

--- a/frontend/app/src/main/java/com/example/frontend/extrafunc/CategoryScore.kt
+++ b/frontend/app/src/main/java/com/example/frontend/extrafunc/CategoryScore.kt
@@ -1,0 +1,33 @@
+package com.example.frontend
+
+
+data class CategoryScore(
+    val category: String,
+    val totalItems: Int,
+    val consumedItems: Int,
+    val wastedItems: Int,
+    val freshItems: Int
+) {
+    val score: Int
+        get() = if (totalItems > 0) (consumedItems * 100) / totalItems else 0
+}
+
+// **카테고리별 점수 분석**
+fun calculateCategoryScores(ingredientList: List<Ingredient>): List<CategoryScore> {
+    val categoryGroups = ingredientList.groupBy { it.category }
+
+    return categoryGroups.map { (category, ingredients) ->
+        val consumed = ingredients.count { it.state == IngredientState.CONSUMED }
+        val wasted = ingredients.count { it.state == IngredientState.WASTED }
+        val fresh = ingredients.count { it.state == IngredientState.FRESH }
+        val total = ingredients.size
+
+        CategoryScore(
+            category = category,
+            totalItems = total,
+            consumedItems = consumed,
+            wastedItems = wasted,
+            freshItems = fresh
+        )
+    }.sortedByDescending { it.score } // 점수 높은 순 정렬
+}

--- a/frontend/app/src/main/java/com/example/frontend/extrafunc/DDayBar.kt
+++ b/frontend/app/src/main/java/com/example/frontend/extrafunc/DDayBar.kt
@@ -20,12 +20,13 @@ import java.time.temporal.ChronoUnit
 @Composable
 fun DDayBar(
     //fridgeList: List<Ingredient>
-    historyList: SnapshotStateList<Ingredient>
+    //historyList: SnapshotStateList<Ingredient>
 ) {
-
-    val sortedIngredients = historyList
+    val sortedIngredients = fridgeList
         .filter { it.state == IngredientState.FRESH } // 신선 상태만 필터링
-    Log.d("FridgeListLog", "DDayBar에 전달된 fridgeList: $historyList")
+        .sortedBy { it.expiryDate } // 유통기한이 빠른 순으로 정렬
+        .take(3) // 가장 빠른 3개만 선택
+    Log.d("FridgeListLog", "DDayBar에 전달된 fridgeList: $fridgeList")
 
     Row(
         modifier = Modifier
@@ -67,7 +68,7 @@ fun DDayBar(
                 Text(
                     text = "D-$dDay",
                     fontSize = 12.sp,
-                    color = dDayColor // ✅ D-Day 색상 적용
+                    color = dDayColor //D-Day 색상 적용
                 )
                 Text(
                     text = ingredient.name,

--- a/frontend/app/src/main/java/com/example/frontend/extrafunc/FreshCheckApp.kt
+++ b/frontend/app/src/main/java/com/example/frontend/extrafunc/FreshCheckApp.kt
@@ -5,6 +5,7 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
+import com.example.frontend.AnalysisScreen
 import com.example.frontend.CalendarScreen
 import com.example.frontend.CameraScreen
 import com.example.frontend.FridgeScreen
@@ -15,6 +16,7 @@ import com.example.frontend.MainScreen
 import com.example.frontend.ReciptScreen
 import com.example.frontend.RegisterScreen
 import com.example.frontend.Routes
+import com.example.frontend.SettingScreen
 import com.example.frontend.historyListState
 
 
@@ -67,6 +69,16 @@ fun FreshCheckApp() {
             //소비/낭비 내역 추가
             composable(Routes.HistoryListScreen) {
                 HistoryListScreen(navController, historyListState)
+            }
+
+            // 분석화면 추가
+            composable(Routes.AnalysisScreen) {
+                AnalysisScreen(navController)
+            }
+
+            // 설정 추가
+            composable(Routes.SettingScreen) {
+                SettingScreen(navController)
             }
 
         })


### PR DESCRIPTION
1. 분석 페이지, 분석 상세 페이지 추가
2. 세팅 화면(임시) 추가
3. 경로 추가 및 설정
4. 소비/낭비 내역 보이기 오류 수정( 카테고리 품목 겹치는 오류)
5. Dday 3개까지만 뜨게 변경
6. 재료에 상태변경 날짜 추가(언제 소비/낭비 되었느지)
7. 달력 재료와 연동해 밑줄 및 일자 클릭시 간단한 내용 출력